### PR TITLE
Fix deploy workflow for Optimism repos and add wallet linking docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Copy yesterday's stats for all tracked repositories
         run: |
           YESTERDAY=$(date -d "yesterday" +'%Y-%m-%d')
-          echo "📅 Processing stats for date: ${YESTERDAY}"
+          echo "Processing stats for date: ${YESTERDAY}"
 
           # Find all repository directories and copy stats files
           for repo_dir in data/ethereum-optimism_*/; do
@@ -78,13 +78,13 @@ jobs:
 
             if [ -f "$stats_file" ]; then
               cp "$stats_file" "$target_file"
-              echo "✅ Copied stats for ${repo_name}"
+              echo "Copied stats for ${repo_name}"
             else
-              echo "⚠️  No stats file found for ${repo_name} on ${YESTERDAY}"
+              echo "Warning: No stats file found for ${repo_name} on ${YESTERDAY}"
             fi
           done
 
-          echo "✨ Stats copy complete"
+          echo "Stats copy complete"
 
       - name: Generate Directory Listings
         uses: jayanta525/github-pages-directory-listing@v4.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,9 +65,26 @@ jobs:
           dump_dir: ${{ env.DATA_DIR }}/dump
           db_path: ${{ env.DATA_DIR }}/db.sqlite
 
-      - name: Get yesterday's date and copy stats
+      - name: Copy yesterday's stats for all tracked repositories
         run: |
-          cp data/elizaos_eliza/stats/day/stats_$(date -d "yesterday" +'%Y-%m-%d').json data/elizaos_eliza/stats/day/stats.json
+          YESTERDAY=$(date -d "yesterday" +'%Y-%m-%d')
+          echo "📅 Processing stats for date: ${YESTERDAY}"
+
+          # Find all repository directories and copy stats files
+          for repo_dir in data/ethereum-optimism_*/; do
+            repo_name=$(basename "$repo_dir")
+            stats_file="${repo_dir}stats/day/stats_${YESTERDAY}.json"
+            target_file="${repo_dir}stats/day/stats.json"
+
+            if [ -f "$stats_file" ]; then
+              cp "$stats_file" "$target_file"
+              echo "✅ Copied stats for ${repo_name}"
+            else
+              echo "⚠️  No stats file found for ${repo_name} on ${YESTERDAY}"
+            fi
+          done
+
+          echo "✨ Stats copy complete"
 
       - name: Generate Directory Listings
         uses: jayanta525/github-pages-directory-listing@v4.0.0

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ A modern analytics pipeline for tracking and analyzing GitHub contributions acro
 - Daily, weekly, and monthly reports
 - Smart contributor scoring system
 
+## Wallet Linking (Optional Feature)
+
+Contributors can optionally link their Ethereum and Solana wallet addresses to their GitHub profiles. When configured, users can authenticate via GitHub OAuth and store wallet addresses in their profile README.
+
+**Setup:** See [`auth-worker/README.md`](auth-worker/README.md) for Cloudflare Worker deployment and OAuth configuration.
+
+**Required secrets (if enabling):**
+
+- `NEXT_PUBLIC_GITHUB_CLIENT_ID` - GitHub OAuth App Client ID
+- `NEXT_PUBLIC_AUTH_WORKER_URL` - Deployed Cloudflare Worker URL
+
+**Note:** The leaderboard works perfectly fine without this feature. It's purely additive.
+
 ## Setup
 
 1. Install dependencies:
@@ -44,6 +57,10 @@ LARGE_MODEL=openai/gpt-4o-mini
 # Optional site info
 SITE_URL=https://your-deployment-url.com
 SITE_NAME="Optimism Contributor Leaderboard"
+
+# Optional: For wallet linking feature
+NEXT_PUBLIC_GITHUB_CLIENT_ID=
+NEXT_PUBLIC_AUTH_WORKER_URL=
 ```
 
 Then load the environment variables:


### PR DESCRIPTION
## Summary

- Fixes deploy workflow to work with Optimism repository structure
- Adds documentation for optional wallet linking feature

## Changes

### Deploy Workflow Fix
**Problem:** Deploy workflow was failing because it tried to copy stats from hardcoded `elizaos_eliza` path, but this project tracks 14 `ethereum-optimism_*` repositories.

**Solution:** Replace hardcoded path with dynamic loop that processes all tracked repos:
```bash
for repo_dir in data/ethereum-optimism_*/; do
  # Copy yesterday's stats for each repo
done
```

This makes the workflow:
- ✅ Work with all 14 Optimism repos automatically
- ✅ Future-proof (automatically handles new repos)
- ✅ Better logging with clear success/warning messages

### Documentation Updates
- Added "Wallet Linking (Optional Feature)" section to README
- Documents the GitHub OAuth + Cloudflare Worker setup
- Makes clear the feature is optional and site works without it
- Added environment variables to example

## Database Size Question
The workflow successfully restores the 164MB database because:
1. **Git doesn't store the .sqlite file directly** - it's in .gitignore
2. **Uses sqlite-diffable format** - database is stored as text dumps in `data/dump/` (~118MB)
3. **Restoration process**:
   - `restore-db` action pulls the dump files from `_data` branch
   - Converts them back to `data/db.sqlite` during the workflow
   - Never commits the 164MB binary file to git

This is why the "Restore database" step succeeded while "Get yesterday's date and copy stats" failed.

## Testing
- [x] Workflow change tested locally (verified dynamic loop works)
- [x] README documentation is clear and accurate
- [ ] Needs workflow run to verify fix in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)