### PR TITLE
fix: add 'use client' directives for RSC compatibility

### DIFF
--- a/src/app/summary/[interval]/[[...date]]/components/StatCardsDisplay.tsx
+++ b/src/app/summary/[interval]/[[...date]]/components/StatCardsDisplay.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { StatCard } from "@/components/stat-card";
 import { CounterWithIcon } from "@/components/counter-with-icon";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -25,7 +27,7 @@ interface Contributor {
   totalScore: number;
 }
 
-export async function StatCardsDisplay({ metrics }: StatCardsDisplayProps) {
+export function StatCardsDisplay({ metrics }: StatCardsDisplayProps) {
   const timeframeTitle = formatTimeframeTitle(
     metrics.interval.intervalStart,
     metrics.interval.intervalType,

--- a/src/components/stat-card.tsx
+++ b/src/components/stat-card.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from "react";
+"use client";
+
+import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,


### PR DESCRIPTION
## Summary
Add missing client directives to components using React hooks.

## Changes
- `src/app/summary/[interval]/[[...date]]/components/StatCardsDisplay.tsx`
- `src/components/stat-card.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)